### PR TITLE
Full LENZ ingest

### DIFF
--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -36,6 +36,7 @@ class ExtractionDefinition < ApplicationRecord
 
   validates :name, uniqueness: true
   validates :split_selector, presence: true, if: :split?
+  validates :s3_bucket, presence: true, if: :s3?
 
   validates :throttle, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 60_000 }
 

--- a/db/migrate/20240410225639_add_s3_fields_to_extraction_type.rb
+++ b/db/migrate/20240410225639_add_s3_fields_to_extraction_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddS3FieldsToExtractionType < ActiveRecord::Migration[7.0]
+  def change
+    add_column :extraction_definitions, :s3, :boolean, default: false, null: false
+    add_column :extraction_definitions, :s3_bucket, :string
+    add_column :extraction_definitions, :s3_arguments, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_05_235829) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_10_225639) do
   create_table "destinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "url", null: false
@@ -40,6 +40,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_05_235829) do
     t.boolean "split", default: false, null: false
     t.string "split_selector"
     t.boolean "extract_text_from_file", default: false, null: false
+    t.boolean "s3", default: false, null: false
+    t.string "s3_bucket"
+    t.string "s3_arguments"
     t.index ["destination_id"], name: "index_extraction_definitions_on_destination_id"
     t.index ["last_edited_by_id"], name: "index_extraction_definitions_on_last_edited_by_id"
     t.index ["name"], name: "index_extraction_definitions_on_name", unique: true

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe ExtractionDefinition do
 
       it { is_expected.to validate_presence_of(:split_selector).with_message("can't be blank") } 
     end
+
+    context 'when the extraction definition comes from S3' do
+      subject! { build(:extraction_definition, pipeline: pipeline1, s3: true) }
+
+      it { is_expected.to validate_presence_of(:s3_bucket).with_message("can't be blank") }
+    end
   end
 
   describe '#validation numericality' do


### PR DESCRIPTION
As an API user I want access to all LENZ data so I can build out demo experiences on the NZL website

**Acceptance criteria**
- Ensure that security controls and steps are followed as per [protocol document](https://nzpco.sharepoint.com/:w:/s/WebDevDataAggregation/EWbhMvIvoV5JoEAtKCSMZXQB25BomLHMyWPo7H9Sgt7tgw?e=DxMzHw)
- Confirm appearance of S3 bucket that holds copy of LENZ source data
- Consider the best way to store this source data for ongoing access
- Consider the best way to store PDFs for ongoing access
- NZL website demo confirms the fields needed for their search and access experiences
- Mapping rules from source fields to API schema is confirmed with the Tech Lead before processing
- All required data is available in the API


**Notes**
* Suggest that time is spent on confirming data requirements for the demo website to limit the need for frequent ingestion
* See the structure of stored data public data https://www.legislation.govt.nz/subscribe/
* Transfer protocol is documented at https://nzpco.sharepoint.com/:w:/s/WebDevDataAggregation/EWbhMvIvoV5JoEAtKCSMZXQB25BomLHMyWPo7H9Sgt7tgw?e=DxMzHw

Acts       SoD 79.4GB        3,625,900 Files, 39,346 Folders
Bills        SoD 4.51GB        239,702 Files, 7,145 Folders
Regulations         SoD 24.4GB        803,340 Files, 54,437 Folders
SOPs      SoD 876MB        47,652 Files, 4,934 Folders

Plus Agency, Deemed Regs, etc, which are much smaller.
