### PR TITLE
Load Retry

### DIFF
--- a/app/supplejack/load/execution.rb
+++ b/app/supplejack/load/execution.rb
@@ -19,7 +19,7 @@ module Load
                    enrichment_request
                  end
 
-      return unless response.status == 500
+      return response unless response.status == 500
 
       raise StandardError, 'Destination API responded with status 500'
     end

--- a/app/supplejack/load/execution.rb
+++ b/app/supplejack/load/execution.rb
@@ -13,11 +13,15 @@ module Load
     end
 
     def call
-      if @harvest_definition.harvest?
-        harvest_request
-      elsif @harvest_definition.enrichment?
-        enrichment_request
-      end
+      response = if @harvest_definition.harvest?
+                   harvest_request
+                 elsif @harvest_definition.enrichment?
+                   enrichment_request
+                 end
+
+      return unless response.status == 500
+
+      raise StandardError, 'Destination API responded with status 500'
     end
 
     private

--- a/spec/sidekiq/load_worker_spec.rb
+++ b/spec/sidekiq/load_worker_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe LoadWorker, type: :job do
       end
 
       it 'retries the Load Execution' do
-        expect(Load::Execution).to receive(:new).exactly(5).times
+        expect(Load::Execution).to receive(:new).exactly(10).times
 
         described_class.new.perform(harvest_job.id, "[{\"transformed_record\":{\"internal_identifier\":\"test\"}}]")
       end


### PR DESCRIPTION
When the API responds with a 500 we weren't raising an error so the retry logic wasn't actually doing anything. 
Typical reasons for the API to respond with a 500 is through a timeout due to a large volume of requests being sent too it.