### PR TITLE
Fix issue with harvests that use an existing extraction

### DIFF
--- a/app/sidekiq/harvest_worker.rb
+++ b/app/sidekiq/harvest_worker.rb
@@ -24,6 +24,7 @@ class HarvestWorker < ApplicationWorker
     ExtractionWorker.perform_async(extraction_job.id, @harvest_report.id)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def create_transformation_jobs
     extraction_job = @pipeline_job.extraction_job
     @harvest_job.update(extraction_job_id: extraction_job.id)
@@ -38,6 +39,7 @@ class HarvestWorker < ApplicationWorker
       break if @pipeline_job.cancelled? || page_number_reached?(page)
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/sidekiq/harvest_worker.rb
+++ b/app/sidekiq/harvest_worker.rb
@@ -31,7 +31,7 @@ class HarvestWorker < ApplicationWorker
 
     (extraction_job.extraction_definition.page..extraction_job.documents.total_pages).each do |page|
       @harvest_report.increment_pages_extracted!
-      TransformationWorker.perform_async(@harvest_job.id, page)
+      TransformationWorker.perform_in((page * 2).seconds, @harvest_job.id, page)
       @harvest_report.increment_transformation_workers_queued!
 
       @pipeline_job.reload

--- a/app/sidekiq/load_worker.rb
+++ b/app/sidekiq/load_worker.rb
@@ -34,7 +34,7 @@ class LoadWorker
   # :reek:UncommunicativeVariableName
   # this reek has been ignored as 'e' is the variable name wanted by Rubocop
   def process_batch(batch, api_record_id)
-    ::Retriable.retriable(tries: 10, base_interval: 1, multiplier: 2, on_retry: log_retry_attempt) do
+    ::Retriable.retriable(tries: 5, base_interval: 1, multiplier: 2, on_retry: log_retry_attempt) do
       Load::Execution.new(batch, @harvest_job, api_record_id).call
 
       @harvest_report.increment_records_loaded!(batch.count)

--- a/spec/sidekiq/harvest_worker_spec.rb
+++ b/spec/sidekiq/harvest_worker_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe HarvestWorker, type: :job do
       end
 
       it 'queues a number of TransformationWorkers based on the number of pages in the Extracted document' do
-        expect(TransformationWorker).to receive(:perform_async).exactly(5).times.and_call_original
+        expect(TransformationWorker).to receive(:perform_in).exactly(5).times.and_call_original
 
         HarvestWorker.new.perform(harvest_job.id)
       end
@@ -90,7 +90,7 @@ RSpec.describe HarvestWorker, type: :job do
         end
 
         it 'queues a number of TransformationWorkers based on the number specified in the PipelineJob' do
-          expect(TransformationWorker).to receive(:perform_async).exactly(2).times.and_call_original
+          expect(TransformationWorker).to receive(:perform_in).exactly(2).times.and_call_original
 
           HarvestWorker.new.perform(harvest_job.id)
         end

--- a/spec/sidekiq/load_worker_spec.rb
+++ b/spec/sidekiq/load_worker_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe LoadWorker, type: :job do
       end
 
       it 'retries the Load Execution' do
-        expect(Load::Execution).to receive(:new).exactly(10).times
+        expect(Load::Execution).to receive(:new).exactly(5).times
 
         described_class.new.perform(harvest_job.id, "[{\"transformed_record\":{\"internal_identifier\":\"test\"}}]")
       end


### PR DESCRIPTION
When using an existing extraction the load is not naturally throttled by the extraction process and it goes too fast and overwhelms the API. 