### PR TITLE
Harvests using existing extractions duration time is wrong

### DIFF
--- a/app/models/harvest_report.rb
+++ b/app/models/harvest_report.rb
@@ -42,7 +42,7 @@ class HarvestReport < ApplicationRecord
   %i[extraction transformation load delete].each do |process|
     define_method("#{process}_running!") do
       super()
-      send(:update, "#{process}_start_time" => Time.zone.now)
+      send(:update, "#{process}_start_time" => Time.zone.now) if send("#{process}_start_time").blank?
     end
 
     define_method("#{process}_completed!") do

--- a/spec/models/harvest_report_spec.rb
+++ b/spec/models/harvest_report_spec.rb
@@ -153,6 +153,9 @@ RSpec.describe HarvestReport do
                               transformation_end_time: 5.minutes.ago)
     end
 
+
+
+
     it 'returns nil if there are no times' do
       expect(nil_report.duration_seconds).to be_nil
     end
@@ -338,6 +341,25 @@ RSpec.describe HarvestReport do
       transformation_status: 'completed', load_status: 'running', delete_status: 'completed', records_loaded: 100)
 
       expect(harvest_report.ready_to_delete_previous_records?).to eq false
+    end
+  end
+
+  describe '#extraction_running!' do
+    it 'updates the start time of the report to be the time that this was called' do
+      subject.extraction_running
+      expect(subject.extraction_start_time).not_to be_nil
+    end
+
+    it 'does not overwrite an existing time if it is called subsequently' do
+      subject.extraction_running!
+
+      time = subject.extraction_start_time
+
+      sleep 2
+
+      subject.extraction_running!
+
+      expect(subject.extraction_start_time).to eq time
     end
   end
 end

--- a/spec/models/harvest_report_spec.rb
+++ b/spec/models/harvest_report_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe HarvestReport do
 
   describe '#extraction_running!' do
     it 'updates the start time of the report to be the time that this was called' do
-      subject.extraction_running
+      subject.extraction_running!
       expect(subject.extraction_start_time).not_to be_nil
     end
 


### PR DESCRIPTION
When running a pipeline from an existing extraction, the calculated duration in the jobs table is wrong. 

Eg the regulation harvest takes about 20 minutes, but the table is saying that it takes 2 seconds. 

https://harvester.pco.boost.co.nz/pipelines/36/pipeline_jobs